### PR TITLE
add `font2span` subroutine

### DIFF
--- a/plugin/vim.pl
+++ b/plugin/vim.pl
@@ -84,6 +84,8 @@ sub plugin_vim {
     $text =~ s/(\s|\n)*$//gs;
     $text .= "\n";
 
+    $text = font2span($text);
+
     chdir($pwd);
 
     # 캐쉬에 저장
@@ -96,6 +98,26 @@ sub plugin_vim {
     rmdir ($hashdir) or return "[rmdir fail]";
 
     return $text;
+}
+
+sub font2span {
+    my $html = shift;
+
+    my @colors = $html =~ m/color="#([^"]+)"/g;
+    my %colorMap;
+    $colorMap{$_}++ for @colors;
+    @colors = keys %colorMap;
+
+    my $style = "<style type=\"text/css\">\n";
+    for my $color (@colors) {
+        $style .= "._$color { color: #$color }\n";
+    }
+
+    $style .= "</style>\n";
+    $html = $style . $html;
+    $html =~ s/font color="#/span class="_/g;
+    $html =~ s/\/font/\/span/g;
+    return $html;
 }
 
 1;


### PR DESCRIPTION
kindle 에서의 원활한 소스코드 하이라이팅을 위해 vim 에서 html 에서
font 태그를 embed stylesheet 로 대체

``` html
    <font color="#ff40ff">#!/usr/bin/env perl</font>
    <font color="#ffff00">use strict</font>;
    <font color="#ffff00">use warnings</font>;
    <font color="#ffff00">use </font><font color="#ff6060">5.010</font>;
```

가

``` html
    <style type="text/css">
    ._00ffff { color: #00ffff }
    ._ff6060 { color: #ff6060 }
    ._ffff00 { color: #ffff00 }
    ._8080ff { color: #8080ff }
    ._ff40ff { color: #ff40ff }
    </style>
    <span class="_ff40ff">#!/usr/bin/env perl</span>
    <span class="_ffff00">use strict</span>;
    <span class="_ffff00">use warnings</span>;
    <span class="_ffff00">use </span><span class="_ff6060">5.010</span>;
```

로 바뀜
